### PR TITLE
Refactoring Naming

### DIFF
--- a/src/data_analysis/statistics.rs
+++ b/src/data_analysis/statistics.rs
@@ -38,7 +38,7 @@ impl Stats {
 }
 
 pub fn get_size(game: &GameDebugger) -> usize {
-    let position: Result<BasicBitGrid, _> = game.position().try_into();
+    let position: Result<BasicBitGrid, _> = game.current_position().try_into();
     let position = position.expect("Failed to convert game position to bitgrid");
     let bounds = position.bounding_box();
     if bounds.is_none() {

--- a/src/data_analysis/statistics.rs
+++ b/src/data_analysis/statistics.rs
@@ -55,7 +55,7 @@ pub fn check_positions() {
 
     let mut uhp = UHPInterface::new();
     for (index, game) in games.iter().enumerate() {
-        let output = uhp.command(&format!("newgame {}", game));
+        let output = uhp.run_command(&format!("newgame {}", game));
 
         if output.contains("err") {
             //println!("Failed to load game: {}", game);

--- a/src/game.rs
+++ b/src/game.rs
@@ -39,19 +39,7 @@ pub enum GameResult {
 }
 
 impl GameDebugger {
-    /// Give a list of legal UHP moves starting from the empty board,
-    /// create and return a GameDebugger with positions after the moves are
-    /// played on the board.
-    ///
-    /// assumes Base+MLP
-    pub fn from_moves(moves: &[String]) -> Result<Self> {
-        GameDebugger::from_moves_custom(moves, GameType::MLP)
-    }
-
-    /// Give a list of legal UHP moves starting from the empty board and a game type,
-    /// create and return a GameDebugger with positions after the moves are
-    /// played on the board.
-    pub fn from_moves_custom(moves: &[String], game_type: GameType) -> Result<Self> {
+    pub fn new(moves: &[String], game_type: GameType) -> Result<Self> {
         let annotator = Annotator::new();
         let annotations = vec![annotator];
         let mut game = GameDebugger {
@@ -290,7 +278,7 @@ mod tests {
             String::from(r"bQ bA1-"),
         ];
 
-        let game = GameDebugger::from_moves(&draw).unwrap();
+        let game = GameDebugger::new(&draw, GameType::MLP).unwrap();
         println!("game\n:{}", game.position().to_dsl());
         assert_eq!(game.game_result(), Some(GameResult::Draw));
     }
@@ -321,7 +309,7 @@ mod tests {
             String::from(r"bG1 wB1\"),
         ];
 
-        let game = GameDebugger::from_moves(&draw).unwrap();
+        let game = GameDebugger::new(&draw, GameType::MLP).unwrap();
         println!("game\n:{}", game.position().to_dsl());
         assert_eq!(game.game_result(), Some(GameResult::Draw));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,16 +32,16 @@ enum MainCommands {
     Bitboard { number: u64 },
 }
 
-pub fn run_uhp() {
+pub fn run_universal_hive_protocol() {
     let mut uhp = UHPInterface::new();
     let mut input = String::new();
-    let output = uhp.command("info");
+    let output = uhp.run_command("info");
     print!("{}", output);
 
     loop {
         input.clear();
         std::io::stdin().read_line(&mut input).unwrap();
-        let output = uhp.command(&input);
+        let output = uhp.run_command(&input);
         print!("{}", output);
     }
 }
@@ -49,13 +49,13 @@ pub fn run_uhp() {
 pub fn main() {
     let args = Cli::parse();
     match args.command {
-        Some(MainCommands::Uhp) => run_uhp(),
+        Some(MainCommands::Uhp) => run_universal_hive_protocol(),
         Some(MainCommands::Analyze) => data_analysis::check_positions(),
         Some(MainCommands::Bitboard { number }) => {
             let bitboard = bitgrid::board::AxialBitboard::from_u64(number);
             println!("{}", bitboard);
         }
 
-        None => run_uhp(),
+        None => run_universal_hive_protocol(),
     }
 }


### PR DESCRIPTION
More sane naming and self-documenting code conventions so that code can be grokked at a glance.
Gets rid of `from_position` and `from_position_custom`