### PR TITLE
Pashneal/correct mosquito pillbug interaction

### DIFF
--- a/src/generator/debug.rs
+++ b/src/generator/debug.rs
@@ -9,10 +9,13 @@ use std::collections::HashSet;
 /// It will create new positions according to the rules that govern pieces as if the
 /// game state could not be swapped by the Pillbug.
 ///
-/// For moves of the pillbug and pillbug adjacent pieces, see pillbug_swaps() and pillbug_moves()
+/// For moves of pieces behaving like the pillbug and pillbug adjacent pieces, 
+/// see pillbug_swaps() and pillbug_moves()
 ///
-/// The move generator is only guaranteed to generate moves correctly
-/// for positions that follow the One Hive Rule
+/// The move generator cannot generate moves for positions that don't follow the One Hive Rule. 
+///
+/// Note: the HexGrid is not assumed to be derived from a valid game history, so it may not be a
+/// position that could be reached in an actual game.
 #[derive(Clone, Debug)]
 pub struct PositionGeneratorDebugger {
     grid: HexGrid,
@@ -151,6 +154,7 @@ impl MoveGenerator<HexGrid> for PositionGeneratorDebugger {
         if self.pinned.contains(&location) {
             return vec![];
         }
+
 
         let mut spider_removed = self.grid.clone();
         spider_removed.remove(location);
@@ -378,11 +382,14 @@ impl MoveGenerator<HexGrid> for PositionGeneratorDebugger {
 
     fn pillbug_moves(&mut self, location: HexLocation) -> Vec<HexGrid> {
         let height = self.grid.peek(location).len();
-        debug_assert!(height == 1);
         debug_assert!(
             self.grid.top(location).unwrap().piece_type == PieceType::Pillbug
                 || self.grid.top(location).unwrap().piece_type == PieceType::Mosquito
         );
+
+        if height > 1 {
+            return vec![];
+        }
 
         if self.pinned.contains(&location) {
             return vec![];
@@ -1467,6 +1474,7 @@ mod tests {
         //   -  [x] 0 free spaces, [x] 1 free space, [x] >1 free spaces
         // for pillbug:
         //   - [x] unpinned/ [x] pinned
+        //   - [x] on ground / [x] on top of the hive
 
         // tests covered:
         //  -  >1 free space
@@ -1645,6 +1653,22 @@ mod tests {
                 grid.to_dsl()
             );
         }
+
+        // Pillbug on top of hive, while technically this shouldn't appear in a legal game,
+        // we've specified this behavior for simplicity of implementation, so we should test it 
+        let grid = HexGrid::from_dsl(concat!(
+            ". . . . . . .\n",
+            " . . . a . . .\n",
+            ". . a 2 a . .\n",
+            " . . l a . . .\n",
+            ". . . . . . .\n\n",
+            "start - [0 0]\n\n",
+            "2 - [m P]\n"
+        ));
+        let mut generator = PositionGeneratorDebugger::from_default(&grid);
+        let (pillbug, _) = grid.find(Piece::new(Pillbug, White)).unwrap();
+        let pillbug_moves = generator.pillbug_swaps(pillbug, None);
+        assert!(pillbug_moves.is_empty());
     }
 
     #[test]
@@ -1873,4 +1897,25 @@ mod tests {
         let mosquito_moves = generator.mosquito_moves(mosquito);
         assert!(mosquito_moves.is_empty());
     }
+
+    #[test]
+    pub(crate) fn test_mosquito_swaps_on_hive_2_stack() {
+        use PieceColor::*;
+        use PieceType::*;
+        // A mosquito cannot copy the pillbug's power unless it is on the ground
+        let grid = HexGrid::from_dsl(concat!(
+            ". . . . . . .\n",
+            " . . q . . . .\n",
+            ". a b 2 P . .\n",
+            " . . . . . . .\n",
+            ". . . . . . .\n\n",
+            "start - [0 0]\n\n",
+            "2 - [a M]\n",
+        ));
+        let mut generator = PositionGeneratorDebugger::from_default(&grid);
+        let (mosquito, _) = grid.find(Piece::new(Mosquito, White)).unwrap();
+        let mosquito_moves = generator.pillbug_swaps(mosquito, None);
+        assert!(mosquito_moves.is_empty());
+    }
+
 }

--- a/src/generator/debug.rs
+++ b/src/generator/debug.rs
@@ -461,11 +461,14 @@ impl SwapGenerator<HexGrid> for PositionGeneratorDebugger {
         immobilized: Option<HexLocation>,
     ) -> Vec<HexGrid> {
         let height = self.grid.peek(pillbug_location).len();
-        debug_assert!(height == 1, "The stack must only contain the pillbug");
         debug_assert!(
             self.grid.top(pillbug_location).unwrap().piece_type == PieceType::Pillbug
                 || self.grid.top(pillbug_location).unwrap().piece_type == PieceType::Mosquito
         );
+
+        if height > 1 {
+            return vec![];
+        }
 
         match immobilized {
             Some(loc) if loc == pillbug_location => return vec![],
@@ -574,6 +577,9 @@ impl PositionGenerator<HexGrid> for PositionGeneratorDebugger {
                 PieceType::Pillbug => self.pillbug_moves(location),
             };
 
+            // TODO two violations to consider
+            // 1) If the piece is behaving like a pillbug, it must be on the ground to activate its power
+            // 2) This doesn't consider that a mosquito can copy a pillbug 
             let swaps = match top.piece_type {
                 PieceType::Pillbug => self.pillbug_swaps(location, self.immobilized),
                 _ => Vec::new(),

--- a/src/generator/debug.rs
+++ b/src/generator/debug.rs
@@ -1914,5 +1914,163 @@ mod tests {
         let mosquito_moves = generator.pillbug_swaps(mosquito, None);
         assert!(mosquito_moves.is_empty());
     }
+    #[test]
+    pub(crate) fn test_mosquito_swaps_on_hive_2_stack_regression() {
+        use PieceColor::*;
+
+        // Be sure that swaps are not allowed when the mosquito is upper level
+        let grid = HexGrid::from_dsl(concat!(
+            ". . . . . . .\n",
+            " . . q . . . .\n",
+            ". a b 2 p . .\n",
+            " . . . . . . .\n",
+            ". . . . . . .\n\n",
+            "start - [0 0]\n\n",
+            "2 - [a M]\n",
+        ));
+
+        let expected = vec![
+            HexGrid::from_dsl(concat!(
+                ". . . . . . .\n",
+                " . . q . . . .\n",
+                ". a 2 a p . .\n",
+                " . . . . . . .\n",
+                ". . . . . . .\n\n",
+                "start - [0 0]\n\n",
+                "2 - [b M]\n",
+            )),
+            HexGrid::from_dsl(concat!(
+                ". . . . . . .\n",
+                " . . 2 . . . .\n",
+                ". a b a p . .\n",
+                " . . . . . . .\n",
+                ". . . . . . .\n\n",
+                "start - [0 0]\n\n",
+                "2 - [q M]\n",
+            )),
+            HexGrid::from_dsl(concat!(
+                ". . . . . . .\n",
+                " . . q . . . .\n",
+                ". a b a 2 . .\n",
+                " . . . . . . .\n",
+                ". . . . . . .\n\n",
+                "start - [0 0]\n\n",
+                "2 - [p M]\n",
+            )),
+            HexGrid::from_dsl(concat!(
+                ". . . . . . .\n",
+                " . . q M . . .\n",
+                ". a b a p . .\n",
+                " . . . . . . .\n",
+                ". . . . . . .\n\n",
+                "start - [0 0]\n\n",
+            )),
+            HexGrid::from_dsl(concat!(
+                ". . . . . . .\n",
+                " . . q . . . .\n",
+                ". a b a p . .\n",
+                " . . . M . . .\n",
+                ". . . . . . .\n\n",
+                "start - [0 0]\n\n",
+            )),
+            HexGrid::from_dsl(concat!(
+                ". . . . . . .\n",
+                " . . q . . . .\n",
+                ". a b a p . .\n",
+                " . . M . . . .\n",
+                ". . . . . . .\n\n",
+                "start - [0 0]\n\n",
+            )),
+        ];
+
+        let mut generator = PositionGeneratorDebugger::from_default(&grid);
+        let positions = generator.generate_positions_for(White);
+
+        assert_eq!(positions.len(), expected.len());
+        for grid in expected {
+            assert!(
+                positions.contains(&grid),
+                "Expected grid not found in generated positions: \n{}",
+                grid.to_dsl()
+            );
+        }
+    }
+    #[test]
+    pub(crate) fn test_mosquito_swaps_on_hive_ground_regression() {
+        use PieceColor::*;
+
+        // A mosquito on the ground should be able to copy the pillbug's power
+        let grid = HexGrid::from_dsl(concat!(
+            ". . . . . . .\n",
+            " . . q . . . .\n",
+            ". a b M p . .\n",
+            " . . . . . . .\n",
+            ". . . . . . .\n\n",
+            "start - [0 0]\n\n",
+        ));
+        let expected = vec![
+            HexGrid::from_dsl(concat!(
+                ". . . . . . .\n",
+                " . . q p . . .\n",
+                ". a b M . . .\n",
+                " . . . . . . .\n",
+                ". . . . . . .\n\n",
+                "start - [0 0]\n\n",
+            )),
+            HexGrid::from_dsl(concat!(
+                ". . . . . . .\n",
+                " . . q . . . .\n",
+                ". a b M . . .\n",
+                " . . p . . . .\n",
+                ". . . . . . .\n\n",
+                "start - [0 0]\n\n",
+            )),
+            HexGrid::from_dsl(concat!(
+                ". . . . . . .\n",
+                " . . q . . . .\n",
+                ". a b M . . .\n",
+                " . . . p . . .\n",
+                ". . . . . . .\n\n",
+                "start - [0 0]\n\n",
+            )),
+            HexGrid::from_dsl(concat!(
+                ". . . . . . .\n",
+                " . . . . . . .\n",
+                ". a b M p . .\n",
+                " . . q . . . .\n",
+                ". . . . . . .\n\n",
+                "start - [0 0]\n\n",
+            )),
+            HexGrid::from_dsl(concat!(
+                ". . . . . . .\n",
+                " . . . q . . .\n",
+                ". a b M p . .\n",
+                " . . . . . . .\n",
+                ". . . . . . .\n\n",
+                "start - [0 0]\n\n",
+            )),
+            HexGrid::from_dsl(concat!(
+                ". . . . . . .\n",
+                " . . . . . . .\n",
+                ". a b M p . .\n",
+                " . . . q . . .\n",
+                ". . . . . . .\n\n",
+                "start - [0 0]\n\n",
+            )),
+        ];
+        
+        let mut generator = PositionGeneratorDebugger::from_default(&grid);
+        let positions = generator.generate_positions_for(White);
+
+        assert_eq!(positions.len(), expected.len());
+        for grid in expected {
+            assert!(
+                positions.contains(&grid),
+                "Expected grid not found in generated positions: \n{}",
+                grid.to_dsl()
+            );
+        }
+
+    }
 
 }

--- a/src/generator/debug.rs
+++ b/src/generator/debug.rs
@@ -581,11 +581,9 @@ impl PositionGenerator<HexGrid> for PositionGeneratorDebugger {
                 PieceType::Pillbug => self.pillbug_moves(location),
             };
 
-            // TODO two violations to consider
-            // 1) If the piece is behaving like a pillbug, it must be on the ground to activate its power
-            // 2) This doesn't consider that a mosquito can copy a pillbug 
             let swaps = match top.piece_type {
                 PieceType::Pillbug => self.pillbug_swaps(location, self.immobilized),
+                PieceType::Mosquito => self.pillbug_swaps(location, self.immobilized),
                 _ => Vec::new(),
             };
 
@@ -2062,7 +2060,14 @@ mod tests {
         let mut generator = PositionGeneratorDebugger::from_default(&grid);
         let positions = generator.generate_positions_for(White);
 
-        assert_eq!(positions.len(), expected.len());
+        for position in &positions {
+            assert!(
+                expected.contains(position),
+                "Generated position not found in expected: \n{}",
+                position.to_dsl()
+            );
+        }
+
         for grid in expected {
             assert!(
                 positions.contains(&grid),

--- a/src/generator/debug.rs
+++ b/src/generator/debug.rs
@@ -6,15 +6,12 @@ use crate::generator::*;
 use std::collections::HashSet;
 
 /// Represents a HexGrid wrapper that can generate new positions.
-/// It will create new positions according to the rules that govern pieces as if the
-/// game state could not be swapped by the Pillbug.
+/// It will create new positions according to the rules that govern pieces as 
+/// specified in the MoveGenerator and SwapGenerator traits. 
 ///
-/// For moves of pieces behaving like the pillbug and pillbug adjacent pieces, 
-/// see pillbug_swaps() and pillbug_moves()
+/// The PositionGeneratorDebugger cannot generate moves for HexGrids that don't follow the One Hive Rule.  
 ///
-/// The move generator cannot generate moves for positions that don't follow the One Hive Rule. 
-///
-/// Note: the HexGrid is not assumed to be derived from a valid game history, so it may not be a
+/// Note: the HexGrid is not assumed to be derived from a valid game history, so it may represent a 
 /// position that could be reached in an actual game.
 #[derive(Clone, Debug)]
 pub struct PositionGeneratorDebugger {

--- a/src/generator/generator.rs
+++ b/src/generator/generator.rs
@@ -21,28 +21,28 @@ pub trait FromHexGrid {
 
 pub trait MoveGenerator<Position: IntoPieces>: FromHexGrid {
     /// Returns a list of all possible moves for a spider at a given location
-    /// if the spider is not covered by any other pieces.
+    /// if the spider is not covered by any other pieces and is on the ground.
     /// (ignores pillbug swaps)
     fn spider_moves(&mut self, location: HexLocation) -> Vec<Position> {
         unimplemented!();
     }
 
     /// Returns a list of all possible moves for a grasshopper at a given location
-    /// if the grasshopper is not covered by any other pieces.
+    /// if the grasshopper is not covered by any other pieces and is on the ground.
     /// (ignores pillbug swaps)
     fn grasshopper_moves(&mut self, location: HexLocation) -> Vec<Position> {
         unimplemented!();
     }
 
     /// Returns a list of all possible moves for a queen at a given location
-    /// if the queen is not covered by any other pieces.
+    /// if the queen is not covered by any other pieces and is on the ground.
     /// (ignores pillbug swaps)
     fn queen_moves(&mut self, location: HexLocation) -> Vec<Position> {
         unimplemented!();
     }
 
     /// Returns a list of all possible moves for an ant at a given location
-    /// if the ant is not covered by any other pieces.
+    /// if the ant is not covered by any other pieces and is on the ground.
     /// (ignores pillbug swaps)
     fn ant_moves(&mut self, location: HexLocation) -> Vec<Position> {
         unimplemented!();
@@ -56,21 +56,22 @@ pub trait MoveGenerator<Position: IntoPieces>: FromHexGrid {
     }
 
     /// Returns a list of all possible moves for a ladybug at a given location
-    /// if the ladybug is not covered by any other pieces.
+    /// if the ladybug is not covered by any other pieces and is on the ground.
     /// (ignores pillbug swaps)
     fn ladybug_moves(&mut self, location: HexLocation) -> Vec<Position> {
         unimplemented!();
     }
 
     /// Returns a list of all possible moves for a pillbug at a given location
-    /// if the pillbug is not covered by any other pieces.
+    /// if the pillbug is not covered by any other pieces. Returns an empty 
+    /// list if the pillbug is not on the ground.
     /// (ignores pillbug swaps)
     fn pillbug_moves(&mut self, location: HexLocation) -> Vec<Position> {
         unimplemented!();
     }
 
     /// Returns a list of all possible moves for a mosquito at a given location
-    /// if the mosquito is not covered by any other pieces.
+    /// if the mosquito is not covered by any other pieces. 
     /// (ignores pillbug swaps)
     fn mosquito_moves(&mut self, location: HexLocation) -> Vec<Position> {
         unimplemented!();
@@ -91,7 +92,7 @@ pub trait PlacementGenerator: FromHexGrid {
 
 pub trait SwapGenerator<Position: IntoPieces>: FromHexGrid {
     /// Returns a list of all positions with each possible swap applied to adjacent pieces by
-    /// the top-facing pillbug at a given *location*.
+    /// a top-facing pillbug at a given *location*.
     ///
     /// Adjacent pieces that are not allowed to be swapped are:
     ///
@@ -101,7 +102,7 @@ pub trait SwapGenerator<Position: IntoPieces>: FromHexGrid {
     /// - pieces that must pass through a gate of height > 1 to slide on/off the top of the pillbug
     ///
     /// Additionally, the pillbug is not able to swap if it is at the immobilized
-    /// location
+    /// location. Returns an empty list if the piece at the pillbug_location is not on the ground.
     fn pillbug_swaps(
         &mut self,
         pillbug_location: HexLocation,

--- a/src/testing_utils/positions.rs
+++ b/src/testing_utils/positions.rs
@@ -309,7 +309,7 @@ pub const PILLBUG_MOVES: [&str; 2] = [
     ),
 ];
 
-pub const PILLBUG_SWAPS: [&str; 11] = [
+pub const PILLBUG_SWAPS: [&str; 12] = [
     concat!(
         ". . . . . . .\n",
         " . . . 2 . . .\n",
@@ -415,6 +415,19 @@ pub const PILLBUG_SWAPS: [&str; 11] = [
         "start - [0 0]\n\n",
         "2 - [m b]\n",
     ),
+    // Technically, this case cannot appear in a legal game,
+    // but we want to be sure that movement for a pillbug on top of the 
+    // hive is well defined + tested - for ease of implementation of the
+    // mosquito, which can copy the pillbug's swapping movement
+    concat!(
+        ". . . . . . .\n",
+        " . . . a . . .\n",
+        ". . a 2 a . .\n",
+        " . . l a . . .\n",
+        ". . . . . . .\n\n",
+        "start - [0 0]\n\n",
+        "2 - [m P]\n"
+    )
 ];
 
 pub const PLACEMENTS: [&str; 3] = [

--- a/src/testing_utils/positions.rs
+++ b/src/testing_utils/positions.rs
@@ -459,7 +459,7 @@ pub const PLACEMENTS: [&str; 3] = [
     ),
 ];
 
-pub const MOSQUITO_MOVES: [&str; 4] = [
+pub const MOSQUITO_MOVES: [&str; 5] = [
     concat!(
         ". . . . . . .\n",
         " . . . . . . .\n",
@@ -495,6 +495,15 @@ pub const MOSQUITO_MOVES: [&str; 4] = [
         ". . . . . . .\n\n",
         "start - [0 0]\n\n",
         "2 - [a B]\n",
+    ),
+    concat!(
+        ". . . . . . .\n",
+        " . . . g . . .\n",
+        ". a b 2 p . .\n",
+        " . . . . . . .\n",
+        ". . . . . . .\n\n",
+        "start - [0 0]\n\n",
+        "2 - [a M]\n",
     ),
 ];
 


### PR DESCRIPTION
## Summary

We've relaxed the rules of implementation for pillbug swaps so that we can reuse the logic for mosquitos. Time will tell if I come to regret this decision though (for example, if we do not have a representation for any non-mosquito / non-beetle piece on top of the hive in other board representations, we might have to tweak our guarantees again).