### PR TITLE
fix: make sure to swap mosquitos only when there is a pillbug

### DIFF
--- a/src/data_analysis/statistics.rs
+++ b/src/data_analysis/statistics.rs
@@ -51,6 +51,7 @@ pub fn get_size(game: &GameDebugger) -> usize {
 pub fn check_positions() {
     let mut stats = Stats::new();
     let games = uhp_strings();
+    println!("GAAAAAMES {}", games.len());
     let mut failures = 0;
 
     let mut uhp = UHPInterface::new();
@@ -58,8 +59,8 @@ pub fn check_positions() {
         let output = uhp.run_command(&format!("newgame {}", game));
 
         if output.contains("err") {
-            //println!("Failed to load game: {}", game);
-            //println!("{}", output);
+            println!("Failed to load game: {}", game);
+            println!("{}", output);
             failures += 1;
             continue;
         }

--- a/src/generator/debug.rs
+++ b/src/generator/debug.rs
@@ -581,9 +581,19 @@ impl PositionGenerator<HexGrid> for PositionGeneratorDebugger {
                 PieceType::Pillbug => self.pillbug_moves(location),
             };
 
-            let swaps = match top.piece_type {
-                PieceType::Pillbug => self.pillbug_swaps(location, self.immobilized),
-                PieceType::Mosquito => self.pillbug_swaps(location, self.immobilized),
+            let neighbors = self.grid.get_neighbors(location);
+            let has_pillbug_neighbor = neighbors.iter().any(|&neighbor| {
+                if let Some(top) = self.grid.top(neighbor) {
+                    top.piece_type == PieceType::Pillbug
+                } else {
+                    false
+                }
+            });
+
+
+            let swaps = match (top.piece_type, has_pillbug_neighbor) {
+                (PieceType::Pillbug, _) => self.pillbug_swaps(location, self.immobilized),
+                (PieceType::Mosquito, true) => self.pillbug_swaps(location, self.immobilized),
                 _ => Vec::new(),
             };
 
@@ -2075,7 +2085,28 @@ mod tests {
                 grid.to_dsl()
             );
         }
+    }
 
+    #[test]
+    pub(crate) fn test_no_moves_available() {
+        use PieceColor::*;
+        // Regression test:
+        // Test a board state where no moves are available to ensure 
+        // it doesn't error out
+        let grid = HexGrid::from_dsl(concat!(
+            ". . . . . .\n",
+            " . . . B . .\n",
+            ". . . . Q .\n",
+            " . L b q . .\n",
+            ". . . m . .\n",
+            " . . . A . .\n",
+            ". . . . . .\n\n",
+            "start - [ -2 -2 ]\n\n",
+        ));
+
+        let mut generator = PositionGeneratorDebugger::from_default(&grid);
+        let positions = generator.generate_positions_for(Black);
+        assert_eq!(positions.len(), 1, "expected 'pass' to be the only legal option");
     }
 
 }

--- a/src/testing_utils/positions.rs
+++ b/src/testing_utils/positions.rs
@@ -649,4 +649,7 @@ pub mod test_suite {
             (M::mosquito_moves, PositionGeneratorDebugger::mosquito_moves),
         )
     }
+
+    // TODO: swap generator tests, especially with mosquito interactions and 
+    // mosquito being beside or not beside a pillbug
 }


### PR DESCRIPTION
## Summary

Found a bug by running games from the dataset through with `cargo run --release anansii -- analyze` following up on this [issue](https://github.com/pashneal/anansii/issues/1). Looks like we were indiscriminately counting swaps as a move in the mosquito's move set. That should only happen when there is a pillbug next to the mosquito

## Future

We should make sure to construct `SwapGenerator` tests that cover just as much ground as the `MoveGenerator` tests - or some sort of parity test that happens automatically regardless of representation. I think, right now, that only exists for moves.