### PR TITLE
Implement pillbug swaps (and mosquito swaps!)

### DIFF
--- a/src/bitgrid/mini.rs
+++ b/src/bitgrid/mini.rs
@@ -288,7 +288,8 @@ impl MiniBitGrid {
                 let height = self.peek(*loc).len() as u8;
                 height == 1
             }).filter(|(d, loc)| {
-                !self.gated(2, *loc, *d)
+                const PILLBUG_HEIGHT: u8 = 1;
+                !self.gated(PILLBUG_HEIGHT + 1, *loc, *d)
             }).map(|(_, loc)| loc)
             .filter(|loc| Some(*loc) != immobilized);
 
@@ -298,9 +299,8 @@ impl MiniBitGrid {
             .filter(|(_, loc)| self.presence(*loc) == false)
             .filter(|(d, _)| {
                 // is not gated off
-                let height = self.peek(location).len() as u8;
-                let effective_height = height + 1;
-                !self.gated(effective_height, location, *d)
+                const PILLBUG_HEIGHT: u8 = 1;
+                !self.gated(PILLBUG_HEIGHT + 1, location, *d)
             }).map(|(_, loc)|  loc);
         
         

--- a/src/bitgrid/mini.rs
+++ b/src/bitgrid/mini.rs
@@ -257,6 +257,56 @@ impl MiniBitGrid {
         grid
     }
 
+    // TODO: will decide on more optimal return type representation 
+    // later, it's very likely not vectors of locations
+    pub fn pillbug_swaps(&self, location: MiniBitGridLocation, immobilized: Option<MiniBitGridLocation>) -> (Vec<MiniBitGridLocation>, Vec<MiniBitGridLocation>){
+        debug_assert!(
+            matches!(
+                self.top(location), 
+                Some(piece) if piece.piece_type == PieceType::Pillbug ||
+                piece.piece_type == PieceType::Mosquito 
+            ),
+            "No top-level swapper at the given location"
+        );
+
+
+        // TODO: optimization - can likely precalculate into lookup table;
+        if self.peek(location).len() != 1 {
+            // pillbug must be on the ground to swap
+            return (Vec::new(), Vec::new());
+        }
+
+        if immobilized.is_some() && immobilized.unwrap() == location {
+            return (Vec::new(), Vec::new());
+        }
+
+        let candidate_sources = Direction::all()
+            .into_iter()
+            .map(|direction| (direction.opposite(), location.apply(direction)))
+            .filter(|(_, loc)| self.presence(*loc) && !self.is_pinned(*loc))
+            .filter(|(_, loc)| {
+                let height = self.peek(*loc).len() as u8;
+                height == 1
+            }).filter(|(d, loc)| {
+                !self.gated(2, *loc, *d)
+            }).map(|(_, loc)| loc)
+            .filter(|loc| Some(*loc) != immobilized);
+
+        let candidate_sinks = Direction::all()
+            .into_iter()
+            .map(|direction| (direction, location.apply(direction)))
+            .filter(|(_, loc)| self.presence(*loc) == false)
+            .filter(|(d, _)| {
+                // is not gated off
+                let height = self.peek(location).len() as u8;
+                let effective_height = height + 1;
+                !self.gated(effective_height, location, *d)
+            }).map(|(_, loc)|  loc);
+        
+        
+        (candidate_sources.collect(), candidate_sinks.collect())
+    }
+
     pub fn grasshopper_moves(&self, location: MiniBitGridLocation) -> MiniGrid {
         debug_assert!(
             self.grasshoppers[location.board_index] & location.mask != 0, 

--- a/src/generator/mini.rs
+++ b/src/generator/mini.rs
@@ -216,7 +216,34 @@ impl MoveGenerator<MiniBitGrid> for MiniGenerator {
     }
 }
 
-impl SwapGenerator<MiniBitGrid> for MiniGenerator {}
+impl SwapGenerator<MiniBitGrid> for MiniGenerator {
+    fn pillbug_swaps(&mut self, location: HexLocation, immobilized: Option<HexLocation>) -> Vec<MiniBitGrid> {
+        // TODO make this a little bit more parametric
+        let location = location.into();
+        let (sources, sinks) = self.grid.pillbug_swaps(location, immobilized.map(|loc| loc.into()));
+        //cartesian product
+        itertools::iproduct!(sources, sinks).map(|(source, sink)| {
+            let piece = self.grid.top(source)
+                .expect("Expected piece at source location");
+            let change = Change {
+                added: Diff{
+                    piece,
+                    board_index: sink.board_index,
+                    mask: sink.mask,
+                },
+                removed: Diff{
+                    piece,
+                    board_index: source.board_index,
+                    mask: source.mask,
+                }
+            };
+            let mut new_grid = self.grid.clone();
+            new_grid.apply_change(change);
+            new_grid
+        }).collect()
+        
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/location.rs
+++ b/src/location.rs
@@ -42,6 +42,18 @@ impl Direction {
             W => (SW, NW),
         }
     }
+
+    pub fn opposite(&self) -> Direction {
+        use Direction::*;
+        match self {
+            NW => SE,
+            NE => SW,
+            E => W,
+            SE => NW,
+            SW => NE,
+            W => E,
+        }
+    }
 }
 
 impl HexLocation {

--- a/src/testing_utils/positions.rs
+++ b/src/testing_utils/positions.rs
@@ -332,7 +332,7 @@ pub const PILLBUG_MOVES: [&str; 2] = [
     ),
 ];
 
-pub const PILLBUG_SWAPS: [&str; 12] = [
+pub const PILLBUG_SWAPS: [&str; 11] = [
     concat!(
         ". . . . . . .\n",
         " . . . 2 . . .\n",
@@ -438,19 +438,6 @@ pub const PILLBUG_SWAPS: [&str; 12] = [
         "start - [0 0]\n\n",
         "2 - [m b]\n",
     ),
-    // Technically, this case cannot appear in a legal game,
-    // but we want to be sure that movement for a pillbug on top of the 
-    // hive is well defined + tested - for ease of implementation of the
-    // mosquito, which can copy the pillbug's swapping movement
-    concat!(
-        ". . . . . . .\n",
-        " . . . a . . .\n",
-        ". . a 2 a . .\n",
-        " . . l a . . .\n",
-        ". . . . . . .\n\n",
-        "start - [0 0]\n\n",
-        "2 - [m P]\n"
-    )
 ];
 
 pub const PLACEMENTS: [&str; 3] = [
@@ -530,7 +517,7 @@ pub const MOSQUITO_MOVES: [&str; 5] = [
     ),
 ];
 
-pub const MOSQUITO_SWAPS: [&str; 5] = [
+pub const MOSQUITO_SWAPS: [&str; 6] = [
     concat!(
         ". . . . . . .\n",
         " . . . . . . .\n",
@@ -576,6 +563,15 @@ pub const MOSQUITO_SWAPS: [&str; 5] = [
         "start - [0 0]\n\n",
         "2 - [a M]\n",
     ),
+    concat!(
+        ". . . . . . .\n",
+        " . . . a . . .\n",
+        ". . a 2 a . .\n",
+        " . . l a . . .\n",
+        ". . . . . . .\n\n",
+        "start - [0 0]\n\n",
+        "2 - [m M]\n"
+    )
 ];
 
 pub mod test_suite {

--- a/src/testing_utils/positions.rs
+++ b/src/testing_utils/positions.rs
@@ -533,7 +533,7 @@ pub const MOSQUITO_SWAPS: [&str; 6] = [
         " . . . . . . .\n",
         ". . . . . . .\n\n",
         "start - [0 0]\n\n",
-        "2 - [a S]\n",
+        "2 - [a b]\n",
     ),
     concat!(
         ". . . . . . .\n",
@@ -543,7 +543,7 @@ pub const MOSQUITO_SWAPS: [&str; 6] = [
         ". . . . . . .\n\n",
         "start - [0 0]\n\n",
         "2 - [a M]\n",
-        "2 - [a S]\n",
+        "2 - [a b]\n",
     ),
     concat!(
         ". . . . . . .\n",


### PR DESCRIPTION
This PR implements both pillbug and mosquito *swaps*. Also corrects a few test boards that could not be constructed according to the rules of `MiniBitGrids` (we only allow mosquitos and beetles in the upper levels).