### PR TITLE
feat: add benchmarking for all moves

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,6 @@ criterion = { version = "0.8", features = ["html_reports"] }
 [[bench]]
 name = "stress_test"
 harness = false
+
+[profile.release]
+debug = true # adds symbols to the release profile

--- a/benches/stress_test.rs
+++ b/benches/stress_test.rs
@@ -16,5 +16,107 @@ fn bench_stress_test_queen(c: &mut Criterion) {
     );
 }
 
-criterion_group!(benches, bench_stress_test_queen);
+fn bench_stress_test_beetle(c: &mut Criterion) {
+    use PieceType::*;
+    use PieceColor::*;
+
+    let mut undoer = Undoer::new();
+    let untimed_run = undoer.untimed_run(200, 47);
+    let tracked_run = undoer.track_piece(untimed_run, Piece::new(Beetle, White));
+
+    c.bench_function("stress_test_beetle", |b| 
+        b.iter(|| undoer.beetle_run(tracked_run.clone()))
+    );
+}
+
+fn bench_stress_test_ant(c: &mut Criterion) {
+    use PieceType::*;
+    use PieceColor::*;
+
+    let mut undoer = Undoer::new();
+    let untimed_run = undoer.untimed_run(200, 48);
+    let tracked_run = undoer.track_piece(untimed_run, Piece::new(Ant, White));
+
+    c.bench_function("stress_test_ant", |b| 
+        b.iter(|| undoer.ant_run(tracked_run.clone()))
+    );
+}
+fn bench_stress_test_spider(c: &mut Criterion) {
+    use PieceType::*;
+    use PieceColor::*;
+
+    let mut undoer = Undoer::new();
+    let untimed_run = undoer.untimed_run(200, 49);
+    let tracked_run = undoer.track_piece(untimed_run, Piece::new(Spider, White));
+
+    c.bench_function("stress_test_spider", |b| 
+        b.iter(|| undoer.spider_run(tracked_run.clone()))
+    );
+}
+fn bench_stress_test_pillbug(c: &mut Criterion) {
+    use PieceType::*;
+    use PieceColor::*;
+
+    let mut undoer = Undoer::new();
+    let untimed_run = undoer.untimed_run(200, 50);
+    let tracked_run = undoer.track_piece(untimed_run, Piece::new(Pillbug, White));
+
+    c.bench_function("stress_test_pillbug", |b| 
+        b.iter(|| undoer.pillbug_run(tracked_run.clone()))
+    );
+}
+fn bench_stress_test_ladybug(c: &mut Criterion) {
+    use PieceType::*;
+    use PieceColor::*;
+
+    let mut undoer = Undoer::new();
+    let untimed_run = undoer.untimed_run(200, 51);
+    let tracked_run = undoer.track_piece(untimed_run, Piece::new(Ladybug, White));
+
+    c.bench_function("stress_test_ladybug", |b| 
+        b.iter(|| undoer.ladybug_run(tracked_run.clone()))
+    );
+}
+fn bench_stress_test_mosquito(c: &mut Criterion) {
+    use PieceType::*;
+    use PieceColor::*;
+
+    let mut undoer = Undoer::new();
+    let untimed_run = undoer.untimed_run(200, 52);
+    let tracked_run = undoer.track_piece(untimed_run, Piece::new(Mosquito, White));
+
+    c.bench_function("stress_test_mosquito", |b| 
+        b.iter(|| undoer.mosquito_run(tracked_run.clone()))
+    );
+}
+fn bench_stress_test_grasshopper(c: &mut Criterion) {
+    use PieceType::*;
+    use PieceColor::*;
+
+    let mut undoer = Undoer::new();
+    let untimed_run = undoer.untimed_run(200, 53);
+    let tracked_run = undoer.track_piece(untimed_run, Piece::new(Grasshopper, White));
+
+    c.bench_function("stress_test_grasshopper", |b| 
+        b.iter(|| undoer.grasshopper_run(tracked_run.clone()))
+    );
+}
+
+
+
+
+
+
+
+criterion_group!(
+    benches,
+    bench_stress_test_queen, 
+    bench_stress_test_beetle,
+    bench_stress_test_spider,
+    bench_stress_test_ladybug,
+    bench_stress_test_mosquito,
+    bench_stress_test_pillbug,
+    bench_stress_test_grasshopper,
+    bench_stress_test_ant,
+);
 criterion_main!(benches);

--- a/src/generator/undoer.rs
+++ b/src/generator/undoer.rs
@@ -118,6 +118,117 @@ impl Undoer {
         }
     }
 
+    // NOTE: Be sure to initialize with a new MiniGenerator/Undoer so that 
+    // the implementor can't cheat the benchmark by anticipating
+    // the moves. Minor risk but adds more validity to the benchmark.
+    pub fn beetle_run(&mut self, tracked_changes: Vec<(Change, Option<MiniBitGridLocation>)>) {
+        for (change, piece_location) in tracked_changes.iter() {
+            self.generator.apply(*change);
+            if let Some(location) = piece_location {
+                black_box(self.generator.current_grid().beetle_moves(*location));
+            }
+        }
+
+        for (change, _) in tracked_changes.iter().rev() {
+            self.generator.undo(*change);
+        }
+    }
+
+    // NOTE: Be sure to initialize with a new MiniGenerator/Undoer so that 
+    // the implementor can't cheat the benchmark by anticipating
+    // the moves. Minor risk but adds more validity to the benchmark.
+    pub fn pillbug_run(&mut self, tracked_changes: Vec<(Change, Option<MiniBitGridLocation>)>) {
+        for (change, piece_location) in tracked_changes.iter() {
+            self.generator.apply(*change);
+            if let Some(location) = piece_location {
+                black_box(self.generator.current_grid().pillbug_moves(*location));
+            }
+        }
+
+        for (change, _) in tracked_changes.iter().rev() {
+            self.generator.undo(*change);
+        }
+    }
+
+    // NOTE: Be sure to initialize with a new MiniGenerator/Undoer so that 
+    // the implementor can't cheat the benchmark by anticipating
+    // the moves. Minor risk but adds more validity to the benchmark.
+    pub fn grasshopper_run(&mut self, tracked_changes: Vec<(Change, Option<MiniBitGridLocation>)>) {
+        for (change, piece_location) in tracked_changes.iter() {
+            self.generator.apply(*change);
+            if let Some(location) = piece_location {
+                black_box(self.generator.current_grid().grasshopper_moves(*location));
+            }
+        }
+
+        for (change, _) in tracked_changes.iter().rev() {
+            self.generator.undo(*change);
+        }
+    }
+
+    // NOTE: Be sure to initialize with a new MiniGenerator/Undoer so that 
+    // the implementor can't cheat the benchmark by anticipating
+    // the moves. Minor risk but adds more validity to the benchmark.
+    pub fn ant_run(&mut self, tracked_changes: Vec<(Change, Option<MiniBitGridLocation>)>) {
+        for (change, piece_location) in tracked_changes.iter() {
+            self.generator.apply(*change);
+            if let Some(location) = piece_location {
+                black_box(self.generator.current_grid().ant_moves(*location));
+            }
+        }
+
+        for (change, _) in tracked_changes.iter().rev() {
+            self.generator.undo(*change);
+        }
+    }
+
+    // NOTE: Be sure to initialize with a new MiniGenerator/Undoer so that 
+    // the implementor can't cheat the benchmark by ladybugicipating
+    // the moves. Minor risk but adds more validity to the benchmark.
+    pub fn ladybug_run(&mut self, tracked_changes: Vec<(Change, Option<MiniBitGridLocation>)>) {
+        for (change, piece_location) in tracked_changes.iter() {
+            self.generator.apply(*change);
+            if let Some(location) = piece_location {
+                black_box(self.generator.current_grid().ladybug_moves(*location));
+            }
+        }
+
+        for (change, _) in tracked_changes.iter().rev() {
+            self.generator.undo(*change);
+        }
+    }
+
+    // NOTE: Be sure to initialize with a new MiniGenerator/Undoer so that 
+    // the implementor can't cheat the benchmark by mosquitoicipating
+    // the moves. Minor risk but adds more validity to the benchmark.
+    pub fn mosquito_run(&mut self, tracked_changes: Vec<(Change, Option<MiniBitGridLocation>)>) {
+        for (change, piece_location) in tracked_changes.iter() {
+            self.generator.apply(*change);
+            if let Some(location) = piece_location {
+                black_box(self.generator.current_grid().mosquito_moves(*location));
+            }
+        }
+
+        for (change, _) in tracked_changes.iter().rev() {
+            self.generator.undo(*change);
+        }
+    }
+
+    // NOTE: Be sure to initialize with a new MiniGenerator/Undoer so that 
+    // the implementor can't cheat the benchmark by anticipating
+    // the moves. Minor risk but adds more validity to the benchmark.
+    pub fn spider_run(&mut self, tracked_changes: Vec<(Change, Option<MiniBitGridLocation>)>) {
+        for (change, piece_location) in tracked_changes.iter() {
+            self.generator.apply(*change);
+            if let Some(location) = piece_location {
+                black_box(self.generator.current_grid().spider_moves(*location));
+            }
+        }
+
+        for (change, _) in tracked_changes.iter().rev() {
+            self.generator.undo(*change);
+        }
+    }
 }
 
 


### PR DESCRIPTION
Except for swaps, we now have benchmarking for all moves. As expected the two slowest functions are `is_pinned` and `single_step` and the DFS for ant moves dominates much of the run (it's almost 100x slower than some of the other bugs).