### PR TITLE
feat(performance): Use O(n) cut vertices to collect all pinned pieces together

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ clap = { version = "4.5.22", features = ["derive"] }
 itertools = "0.13.0"
 rand = { version = "0.10.1", features = ["chacha"] }
 regex = "1.11.1"
+rustc-hash = "2.1.2"
 thiserror = "2.0.3"
 
 [dev-dependencies]

--- a/benches/stress_test.rs
+++ b/benches/stress_test.rs
@@ -102,12 +102,6 @@ fn bench_stress_test_grasshopper(c: &mut Criterion) {
     );
 }
 
-
-
-
-
-
-
 criterion_group!(
     benches,
     bench_stress_test_queen, 

--- a/src/bitgrid/mini.rs
+++ b/src/bitgrid/mini.rs
@@ -1,9 +1,10 @@
 use super::*;
 use crate::generator::change::{Change, Diff};
+use crate::generator::cut_vertices::cut_vertices;
 use crate::hex_grid::{GridBounds, HexGrid, HexGridConvertible, FromWrappingHexes, IntoWrappingHexes};
 use crate::location::{Direction, FromHexLocation, HexLocation, Shiftable};
-use crate::piece::{IntoPieces, Piece, PieceColor, PieceType};
-use std::collections::HashSet;
+use crate::piece::{IntoPieces, Piece, PieceColor, PieceType, Peekable};
+use std::collections::{HashSet, HashMap};
 use std::fmt::{self, Display};
 
 const LEFT_OVERFLOW_MASK: u64 = 0x8080808080808080;
@@ -71,6 +72,7 @@ pub struct MiniBitGrid {
     outside: MiniGrid,
     white_pieces: MiniGrid,
     black_pieces: MiniGrid,
+    pinned: MiniGrid,
     stacks: BasicBitStack,
     metainfo: MiniMetaInfo,
 }
@@ -108,7 +110,6 @@ pub struct MiniBitGridLocation {
 }
 
 
-
 impl MiniBitGrid {
     pub fn new() -> Self {
         MiniBitGrid {
@@ -124,6 +125,7 @@ impl MiniBitGrid {
             outside: [AxialBitboard::empty(); 4],
             white_pieces: [AxialBitboard::empty(); 4],
             black_pieces: [AxialBitboard::empty(); 4],
+            pinned: [AxialBitboard::empty(); 4],
             stacks: BasicBitStack::new(),
             metainfo: MiniMetaInfo::new(),
         }
@@ -249,7 +251,7 @@ impl MiniBitGrid {
             "No queen or mosquito at the top of the given location"
         );
 
-        let pinned = self.is_pinned(location);
+        let pinned = self.is_top_piece_pinned(location);
         if pinned {
             return MiniGrid::default()
         } 
@@ -273,7 +275,7 @@ impl MiniBitGrid {
             "No pillbug or mosquito at the top of the given location"
         );
 
-        let pinned = self.is_pinned(location);
+        let pinned = self.is_top_piece_pinned(location);
         if pinned {
             return MiniGrid::default()
         } 
@@ -313,7 +315,7 @@ impl MiniBitGrid {
         let candidate_sources = Direction::all()
             .into_iter()
             .map(|direction| (direction.opposite(), location.apply(direction)))
-            .filter(|(_, loc)| self.presence(*loc) && !self.is_pinned(*loc))
+            .filter(|(_, loc)| self.presence(*loc) && !self.is_top_piece_pinned(*loc))
             .filter(|(_, loc)| {
                 let height = self.peek(*loc).len() as u8;
                 height == 1
@@ -347,7 +349,7 @@ impl MiniBitGrid {
             "No grasshopper or mosquito at the given location"
         );
 
-        let pinned = self.is_pinned(location);
+        let pinned = self.is_top_piece_pinned(location);
         if pinned {
             return MiniGrid::default()
         } 
@@ -381,7 +383,7 @@ impl MiniBitGrid {
             "No beetle or mosquito at the top of the given location"
         );
 
-        let pinned = self.is_pinned(location);
+        let pinned = self.is_top_piece_pinned(location);
         if pinned {
             return MiniGrid::default()
         } 
@@ -406,7 +408,7 @@ impl MiniBitGrid {
             "No spider or mosquito at the top of the given location"
         );
 
-        let pinned = self.is_pinned(location);
+        let pinned = self.is_top_piece_pinned(location);
         if pinned {
             return MiniGrid::default()
         } 
@@ -473,7 +475,7 @@ impl MiniBitGrid {
             "No ant or mosquito at the top of given location"
         );
 
-        let pinned = self.is_pinned(location);
+        let pinned = self.is_top_piece_pinned(location);
         if pinned {
             return MiniGrid::default()
         } 
@@ -534,7 +536,7 @@ impl MiniBitGrid {
             "No ladybug or mosquito at the top of given location"
         );
 
-        let pinned = self.is_pinned(location);
+        let pinned = self.is_top_piece_pinned(location);
         if pinned {
             return MiniGrid::default()
         } 
@@ -600,7 +602,7 @@ impl MiniBitGrid {
             "No mosquito at top of the given location"
         );
 
-        let pinned = self.is_pinned(location);
+        let pinned = self.is_top_piece_pinned(location);
         if pinned {
             return MiniGrid::default()
         } 
@@ -792,16 +794,14 @@ impl MiniBitGrid {
         num_connected
     }
 
-    pub fn is_pinned(&self, location: MiniBitGridLocation) -> bool {
+    pub fn is_top_piece_pinned(&self, location: MiniBitGridLocation) -> bool {
         let mut grid = self.all_pieces;
         let height = self.peek(location).len();
         // upper level pieces can't be pinned in the traditional sense
         if height > 1 {
             return false;
         }
-        grid[location.board_index] &= !location.mask;
-        let connected_components = Self::num_connected_components(&grid);
-        connected_components > 1
+        self.pinned[location.board_index] & location.mask != 0
     }
 
     fn neighborhood_to_grid(
@@ -1202,6 +1202,33 @@ impl MiniBitGrid {
         });
     }
 
+    pub fn recalculate_pins(&mut self) {
+        self.pinned = [AxialBitboard::empty(); 4];
+
+        if let Some(location) = self.find_one_hex() {
+            let mut visited = HashSet::new();
+            let mut discovery_time = HashMap::new();
+            let mut low_time = HashMap::new();
+            
+            let cut_vertices = cut_vertices(
+                self, 
+                &mut visited, 
+                &mut discovery_time, 
+                &mut low_time, 
+                location,
+                0, 
+                None
+            );
+
+            for loc in cut_vertices {
+                let board_index = loc.board_index;
+                let mask = loc.mask;
+                self.pinned[board_index] |= mask;
+            }
+
+        } 
+    }
+
     /// TODO: may be a candidate for optimization
     pub fn apply_change(&mut self, change: Change) {
         let piece = change.added.piece;
@@ -1209,14 +1236,6 @@ impl MiniBitGrid {
             board_index: change.added.board_index,
             mask: change.added.mask,
         };
-
-        if self.addition_preserves_one_hive(location) == false {
-            let mut test_grid = self.clone();
-            println!("triggering change: {:?}", change);
-            println!("before illegal addition:\n{:?}", test_grid);
-            test_grid.add_top_unchecked(piece, location);
-            println!("after illegal addition:\n{:?}", test_grid);
-        }
 
         self.add_top(piece, location);
 
@@ -1228,6 +1247,7 @@ impl MiniBitGrid {
             self.remove_top(location);
         }
 
+        self.recalculate_pins();
     }
 
     pub fn placements(&self, color: PieceColor) -> Vec<MiniBitGridLocation> {
@@ -1724,7 +1744,15 @@ impl TryFrom<HexGrid> for MiniBitGrid {
             "Expected number of stacks in HexGrid and MiniBitGrid to match",
         );
 
+        mini.recalculate_pins();
         Ok(mini)
+    }
+}
+
+impl Peekable for MiniBitGrid {
+    type Location = MiniBitGridLocation;
+    fn peek(&self, location: Self::Location) -> Vec<Piece> {
+        self.peek(location)
     }
 }
 
@@ -1736,7 +1764,7 @@ pub mod tests {
 
     #[test]
     pub fn size_sanity_check() {
-        assert_eq!(std::mem::size_of::<MiniBitGrid>(), 416);
+        assert_eq!(std::mem::size_of::<MiniBitGrid>(), 448);
     }
 
     #[test]
@@ -2142,7 +2170,7 @@ pub mod tests {
         ));
 
         for location in pinned_locations {
-            assert!(grid.is_pinned(location.into()));
+            assert!(grid.is_top_piece_pinned(location.into()));
         }
 
         let unpinned_locations = HexGrid::selector(concat!(
@@ -2157,7 +2185,7 @@ pub mod tests {
         ));
 
         for location in unpinned_locations {
-            assert!(!grid.is_pinned(location.into()));
+            assert!(!grid.is_top_piece_pinned(location.into()));
         }
     }
 }

--- a/src/bitgrid/mini.rs
+++ b/src/bitgrid/mini.rs
@@ -4,6 +4,7 @@ use crate::generator::cut_vertices::cut_vertices;
 use crate::hex_grid::{GridBounds, HexGrid, HexGridConvertible, FromWrappingHexes, IntoWrappingHexes};
 use crate::location::{Direction, FromHexLocation, HexLocation, Shiftable};
 use crate::piece::{IntoPieces, Piece, PieceColor, PieceType, Peekable};
+use rustc_hash::{FxHashSet, FxHashMap};
 use std::collections::{HashSet, HashMap};
 use std::fmt::{self, Display};
 
@@ -1206,9 +1207,9 @@ impl MiniBitGrid {
         self.pinned = [AxialBitboard::empty(); 4];
 
         if let Some(location) = self.find_one_hex() {
-            let mut visited = HashSet::new();
-            let mut discovery_time = HashMap::new();
-            let mut low_time = HashMap::new();
+            let mut visited = FxHashSet::default();
+            let mut discovery_time = FxHashMap::default();
+            let mut low_time = FxHashMap::default();
             
             let cut_vertices = cut_vertices(
                 self, 

--- a/src/generator/cut_vertices.rs
+++ b/src/generator/cut_vertices.rs
@@ -1,6 +1,7 @@
 use crate::hex_grid::Shiftable;
 use crate::piece::Peekable;
 use crate::location::Direction;
+use rustc_hash::{FxHashSet, FxHashMap};
 use std::collections::{HashSet, HashMap};
 
 fn neighbors<T: Shiftable>(graph: &impl Peekable<Location = T>, node: &T) -> Vec<T> {
@@ -18,20 +19,20 @@ fn neighbors<T: Shiftable>(graph: &impl Peekable<Location = T>, node: &T) -> Vec
 
 pub fn cut_vertices<T: Shiftable>(
     graph: &impl Peekable<Location = T>, 
-    visited: &mut HashSet<T>, 
-    discovery_time: &mut HashMap<T, u32>,
-    low_time: &mut HashMap<T, u32>,
+    visited: &mut FxHashSet<T>, 
+    discovery_time: &mut FxHashMap<T, u32>,
+    low_time: &mut FxHashMap<T, u32>,
     node: T,
     time: u32,
     parent: Option<&T>,
-) -> HashSet<T> {
+) -> FxHashSet<T> {
     let mut children = 0;
     discovery_time.insert(node.clone(), time);
     low_time.insert(node.clone(), time);
     visited.insert(node.clone());
 
 
-    let mut results = HashSet::new();
+    let mut results = FxHashSet::default();
 
     for neighbor in neighbors(graph, &node) {
         if visited.contains(&neighbor){
@@ -62,7 +63,7 @@ pub fn cut_vertices<T: Shiftable>(
 
         if parent.is_none() && children > 1 {
             results.insert(node.clone());
-        } else if parent.is_some() && lo >= discovery_time[&node] {
+        } else if parent.is_some() && low_time[&neighbor] >= discovery_time[&node] {
             results.insert(node.clone());
         }
     }
@@ -81,9 +82,9 @@ pub mod tests {
 
     #[test]
     fn test_cut_vertices() {
-        let mut visited = HashSet::new();
-        let mut discovery_time = HashMap::new();
-        let mut low_time = HashMap::new();
+        let mut visited = FxHashSet::default();
+        let mut discovery_time = FxHashMap::default();
+        let mut low_time = FxHashMap::default();
         
         let grid = concat!(
             ". . . . . . .\n",
@@ -136,9 +137,9 @@ pub mod tests {
 
     #[test]
     fn test_cut_vertices_regression() {
-        let mut visited = HashSet::new();
-        let mut discovery_time = HashMap::new();
-        let mut low_time = HashMap::new();
+        let mut visited = FxHashSet::default();
+        let mut discovery_time = FxHashMap::default();
+        let mut low_time = FxHashMap::default();
         
         let grid = concat!(
             ". . . . . . . . . . . . . .\n",

--- a/src/generator/cut_vertices.rs
+++ b/src/generator/cut_vertices.rs
@@ -1,0 +1,176 @@
+use crate::hex_grid::Shiftable;
+use crate::piece::Peekable;
+use crate::location::Direction;
+use std::collections::{HashSet, HashMap};
+
+fn neighbors<T: Shiftable>(graph: &impl Peekable<Location = T>, node: &T) -> Vec<T> {
+    let mut neighbors = Vec::new();
+
+    for direction in Direction::all() {
+        let neighbor = node.apply(direction);
+        if !graph.peek(neighbor.clone()).is_empty() {
+            neighbors.push(neighbor);
+        }
+    }
+
+    neighbors
+}
+
+pub fn cut_vertices<T: Shiftable>(
+    graph: &impl Peekable<Location = T>, 
+    visited: &mut HashSet<T>, 
+    discovery_time: &mut HashMap<T, u32>,
+    low_time: &mut HashMap<T, u32>,
+    node: T,
+    time: u32,
+    parent: Option<&T>,
+) -> HashSet<T> {
+    let mut children = 0;
+    discovery_time.insert(node.clone(), time);
+    low_time.insert(node.clone(), time);
+    visited.insert(node.clone());
+
+
+    let mut results = HashSet::new();
+
+    for neighbor in neighbors(graph, &node) {
+        if visited.contains(&neighbor){
+            if let Some(parent_node) = parent {
+                if neighbor != *parent_node {
+                    let min_time = low_time[&node].min(discovery_time[&neighbor]);
+                    low_time.insert(node.clone(), min_time);
+                }
+            }
+            continue
+        }
+
+        children += 1;
+        let mut child_results = cut_vertices(
+            graph, 
+            visited, 
+            discovery_time, 
+            low_time, 
+            neighbor.clone(), 
+            time + 1, 
+            Some(&node)
+        );
+
+        results.extend(child_results.drain());
+
+        let lo = low_time[&neighbor].min(low_time[&node]);
+        low_time.insert(node.clone(), lo);
+
+        if parent.is_none() && children > 1 {
+            results.insert(node.clone());
+        } else if parent.is_some() && lo >= discovery_time[&node] {
+            results.insert(node.clone());
+        }
+    }
+
+    results
+}
+
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use crate::hex_grid::{HexGrid};
+    use crate::piece::PieceType::*;
+    use crate::piece::PieceColor::*;
+    use crate::piece::*;
+
+    #[test]
+    fn test_cut_vertices() {
+        let mut visited = HashSet::new();
+        let mut discovery_time = HashMap::new();
+        let mut low_time = HashMap::new();
+        
+        let grid = concat!(
+            ". . . . . . .\n",
+            " . . L B . Q .\n",
+            ". l M . A S .\n",
+            " . a G . . . .\n",
+            ". . a a . . .\n",
+            " . . . . . . .\n\n",
+            "start - [ 0 -2 ]\n\n",
+        );
+
+        let graph = HexGrid::from_dsl(grid);
+        let node = graph.find(Piece::new(Queen, White)).unwrap().0;
+
+        let cut_vertices = cut_vertices(
+            &graph, 
+            &mut visited, 
+            &mut discovery_time, 
+            &mut low_time, 
+            node,
+            0, 
+            None
+        );
+
+        let beetle = graph.find(Piece::new(Beetle, White)).unwrap().0;
+        let ant  = graph.find(Piece::new(Ant, White)).unwrap().0;
+        let spider = graph.find(Piece::new(Spider, White)).unwrap().0;
+        let ladybug = graph.find(Piece::new(Ladybug, White)).unwrap().0;
+        let mosquito = graph.find(Piece::new(Mosquito, White)).unwrap().0;
+        let grasshopper = graph.find(Piece::new(Grasshopper, White)).unwrap().0;
+
+
+        assert!(cut_vertices.contains(&beetle));
+        assert!(cut_vertices.contains(&ant));
+        assert!(cut_vertices.contains(&spider));
+        assert!(cut_vertices.contains(&ladybug));
+        assert!(cut_vertices.contains(&mosquito));
+        println!("Cut vertices: {:?}", cut_vertices);
+        // for every hex location insert a placeholder/wildcard into a new hexgrid 
+        // so we can debug it
+        let mut debug_grid = HexGrid::new();
+        for loc in cut_vertices.clone(){
+            debug_grid.add(Piece::new(WildCard, White), loc.clone());
+        }
+        println!("Debug grid:\n{}", debug_grid.to_dsl());
+        assert!(!cut_vertices.contains(&node));
+        assert!(!cut_vertices.contains(&grasshopper));
+        assert!(cut_vertices.len() == 5);
+    }
+
+    #[test]
+    fn test_cut_vertices_regression() {
+        let mut visited = HashSet::new();
+        let mut discovery_time = HashMap::new();
+        let mut low_time = HashMap::new();
+        
+        let grid = concat!(
+            ". . . . . . . . . . . . . .\n",
+            " . . . . . Q . . . . . . . .\n",
+            ". . . . . P . . . . . . . .\n",
+            " . . B . . G . . s . . . . .\n",
+            ". . . G 2 m G b a . s g g .\n",
+            " . a S A . . b . a g . A . .\n",
+            ". S . . . . l p . q . . . .\n",
+            " . . . . . M . A . . . . . .\n",
+            ". . . . . . . . . . . . . .\n\n",
+            "start - [ 2 -6 ]\n\n",
+            "2 - [ L B ]\n",
+        );
+
+
+        let graph = HexGrid::from_dsl(grid);
+        let node = graph.find(Piece::new(Queen, White)).unwrap().0;
+
+        let cut_vertices = cut_vertices(
+            &graph, 
+            &mut visited, 
+            &mut discovery_time, 
+            &mut low_time, 
+            node,
+            0, 
+            None
+        );
+
+        let black_ladybug = graph.find(Piece::new(Ladybug, Black)).unwrap().0;
+        assert!(cut_vertices.len() > 0);
+        assert!(cut_vertices.contains(&black_ladybug));
+    }
+}
+

--- a/src/generator/mod.rs
+++ b/src/generator/mod.rs
@@ -3,6 +3,7 @@ pub mod debug;
 pub mod mini;
 pub mod generator;
 pub mod undoer;
+pub mod cut_vertices;
 
 use super::*;
 use change::*;

--- a/src/generator/undoer.rs
+++ b/src/generator/undoer.rs
@@ -69,6 +69,8 @@ impl Undoer {
             let r = rng.random::<i32>().abs() as usize % vec_positions.len(); 
             let random_position = &vec_positions[r];
 
+            println!("generator grid:\n{}", self.generator.current_grid().to_hex_grid().to_dsl());
+            println!("generator position: {}", random_position.to_hex_grid().to_dsl());
             let change = Differ::single_diff(
                 &self.generator.current_grid(), 
                 random_position

--- a/src/generator/undoer.rs
+++ b/src/generator/undoer.rs
@@ -69,8 +69,6 @@ impl Undoer {
             let r = rng.random::<i32>().abs() as usize % vec_positions.len(); 
             let random_position = &vec_positions[r];
 
-            println!("generator grid:\n{}", self.generator.current_grid().to_hex_grid().to_dsl());
-            println!("generator position: {}", random_position.to_hex_grid().to_dsl());
             let change = Differ::single_diff(
                 &self.generator.current_grid(), 
                 random_position

--- a/src/hex_grid.rs
+++ b/src/hex_grid.rs
@@ -55,6 +55,14 @@ pub struct HexGrid {
     fast_grid: HashMap<(usize, usize), Vec<Piece>>,
 }
 
+impl Peekable for HexGrid {
+    type Location = HexLocation;
+
+    fn peek(&self, location: Self::Location) -> Vec<Piece> {
+        self.peek(location)
+    }
+}
+
 impl HexGrid {
     /// Translates a DSL string with "*" characters and reports the
     /// locations of each * on the resulting board

--- a/src/piece.rs
+++ b/src/piece.rs
@@ -180,6 +180,11 @@ impl std::hash::Hash for Piece {
     }
 }
 
+pub trait Peekable {
+    type Location: Shiftable;
+    fn peek(&self, location : Self::Location) -> Vec<Piece>; 
+}
+
 pub trait IntoPieces {
     type PieceLocation: Shiftable;
     /// Returns a list of pieces and their locations in "board order", that


### PR DESCRIPTION
Creates a O(n) way to determine all pinned pieces at the same time. It's a bit slow but I have faith that it will overall be beneficial. The only way to get good benchmarks for this would likely to be have a stress test that goes over multiple pieces that are pinned (as is likely something we have to compute when evaluating the position). 