### PR TITLE
peformance: speed up flood fill and is_pinned performance

### DIFF
--- a/benches/stress_test.rs
+++ b/benches/stress_test.rs
@@ -59,8 +59,9 @@ fn bench_stress_test_pillbug(c: &mut Criterion) {
     use PieceColor::*;
 
     let mut undoer = Undoer::new();
-    let untimed_run = undoer.untimed_run(200, 50);
+    let untimed_run = undoer.untimed_run(200, 57);
     let tracked_run = undoer.track_piece(untimed_run, Piece::new(Pillbug, White));
+    undoer.warmup_gates();
 
     c.bench_function("stress_test_pillbug", |b| 
         b.iter(|| undoer.pillbug_run(tracked_run.clone()))

--- a/src/bitgrid/board.rs
+++ b/src/bitgrid/board.rs
@@ -432,6 +432,10 @@ impl AxialBitboard {
         final_result
     }
 
+    //pub fn left_neighbors_grid(
+        //grid: [AxialBitboard; 4],
+    //) -> AxialBitboard
+
     pub fn neighbors_grid(
         grid: [AxialBitboard; 4], 
         neighborhood_center: usize, 

--- a/src/bitgrid/gates.rs
+++ b/src/bitgrid/gates.rs
@@ -2,13 +2,13 @@ use super::*;
 use crate::location::*;
 use std::sync::OnceLock;
 
-use rustc_hash::{ FxHashMap};
 use itertools::*;
+
+const SURROUND_MAGIC : u64 = 0x1081080000000000;
 
 const SURROUND : AxialBitboard = AxialBitboard(0x30506);
 const TEST_GATE: AxialBitboard = AxialBitboard(0x200);
-static GATES : OnceLock<FxHashMap<AxialBitboard, AxialBitboard>> = OnceLock::new();
-//const STRING: OnceLock<String> = OnceLock::new();
+static GATES : OnceLock<Vec<AxialBitboard>> = OnceLock::new();
 
 fn gated_locations(board: AxialBitboard, center: AxialBitboard) -> AxialBitboard {
     assert!(center.lsb() == center);
@@ -32,10 +32,20 @@ fn gated_locations(board: AxialBitboard, center: AxialBitboard) -> AxialBitboard
         }
     }
 
+    let mut original_neighbors = AxialBitboard(location.mask).centered_neighbors();
+    original_neighbors &= board;
+
+    let mut grid = [AxialBitboard::empty(); 4];
+    grid[location.board_index] |= original_neighbors;
+    let original_reach = AxialBitboard::fast_neighbors_grid(grid, location.board_index); 
+    let original_reach_board = original_reach[location.board_index]; 
+
+    final_board = original_reach_board & final_board;
+
     final_board
 }
 
-fn surround_power_set() -> Vec<AxialBitboard> {
+pub fn surround_power_set() -> Vec<AxialBitboard> {
     SURROUND.into_iter().powerset().map(
         |v| v.into_iter().fold(AxialBitboard(0), |acc, x| acc | x)
     ).collect()
@@ -43,8 +53,18 @@ fn surround_power_set() -> Vec<AxialBitboard> {
 
 pub fn gated_neighbors(board : AxialBitboard, location : MiniBitGridLocation) -> AxialBitboard {
     assert!(AxialBitboard(location.mask).is_centered());
+    let index_func = |x: AxialBitboard| (SURROUND_MAGIC.wrapping_mul(x.to_u64()) >> (64 - 6)) as usize; 
     let boards = GATES.get_or_init(|| {
-        surround_power_set().into_iter().map(|gates| (gates, gated_locations(gates, TEST_GATE))).collect()
+        let powerset : Vec<(AxialBitboard, AxialBitboard)> = surround_power_set()
+            .into_iter()
+            .map(|gates| (gates, gated_locations(gates, TEST_GATE)))
+            .collect();
+        let mut map = vec![AxialBitboard::empty(); powerset.len()];
+        for (gates, value) in powerset {
+            let index = index_func(gates);
+            map[index] = value;
+        }
+        map
     });
     let mut start = AxialBitboard(location.mask);
 
@@ -54,7 +74,7 @@ pub fn gated_neighbors(board : AxialBitboard, location : MiniBitGridLocation) ->
     let mut candidate = board & start;
     if shift >= 0 { candidate <<= shift } else { candidate >>= -shift}
 
-    let solution = boards.get(&candidate).expect("Didn't find board in GATES").clone();
+    let solution = boards[index_func(candidate)];
     let solution = if shift >= 0 {solution >> shift} else { solution << -shift };
 
     solution

--- a/src/bitgrid/mini.rs
+++ b/src/bitgrid/mini.rs
@@ -266,15 +266,8 @@ impl MiniBitGrid {
                 self.all_pieces[location.board_index], 
                 location
             );
-            let mut original_neighbors = AxialBitboard(location.mask).centered_neighbors();
-            original_neighbors &= self.all_pieces[location.board_index];
-
             let mut grid = [AxialBitboard::empty(); 4];
-            grid[location.board_index] |= original_neighbors;
-            let original_reach = AxialBitboard::fast_neighbors_grid(grid, location.board_index); 
-            let original_reach_board = original_reach[location.board_index]; 
-
-            grid[location.board_index] = original_reach_board & gated_neighbors;
+            grid[location.board_index] = gated_neighbors;
             return grid
         }
 
@@ -300,6 +293,17 @@ impl MiniBitGrid {
         if pinned {
             return MiniGrid::default()
         } 
+
+        // Performance optimization: skip single_step if the board is centered
+        if AxialBitboard(location.mask).is_centered() {
+            let gated_neighbors = gated_neighbors(
+                self.all_pieces[location.board_index], 
+                location
+            );
+            let mut grid = [AxialBitboard::empty(); 4];
+            grid[location.board_index] = gated_neighbors;
+            return grid
+        }
 
         let mut grid = [AxialBitboard::empty(); 4]; 
         for location in self.single_step(location, false, 1) {
@@ -754,26 +758,31 @@ impl MiniBitGrid {
     fn flood_fill_step(frontier: &mut MiniGrid, visited: &mut MiniGrid, all_pieces: &MiniGrid) {
         let mut new_frontier = [AxialBitboard::empty(); GRID_SIZE];
 
-        for index in 0..GRID_SIZE {
-            visited[index] |= frontier[index];
+        for i in 0..GRID_SIZE {
+            visited[i] |= frontier[i];
         }
 
         for i in 0..GRID_SIZE {
-            let calculated: [AxialBitboard; 4];
 
-            if frontier[i].is_centered() {
-                calculated = AxialBitboard::fast_neighbors_grid(*frontier, i) 
-            } else {
-                calculated = AxialBitboard::neighbors_grid(*frontier, i);
+            // skip useless frontiers
+            if frontier[i].is_empty() { 
+                continue; 
             }
 
-            for i in 0..GRID_SIZE {
-                new_frontier[i] |= calculated[i] & all_pieces[i] & !visited[i];
+            // todo can do other things
+            let calculated = if frontier[i].is_centered() {
+                AxialBitboard::fast_neighbors_grid(*frontier, i) 
+            } else {
+                AxialBitboard::neighbors_grid(*frontier, i)
+            };
+
+            for j in 0..GRID_SIZE {
+                new_frontier[j] |= calculated[j];
             }
         }
 
-        for index in 0..GRID_SIZE {
-            frontier[index] = new_frontier[index] 
+        for i in 0..GRID_SIZE {
+            frontier[i] = new_frontier[i] & all_pieces[i] & !visited[i];
         }
     }
 
@@ -794,6 +803,30 @@ impl MiniBitGrid {
         }
 
         visited
+    }
+
+    pub fn fast_single_connected_component(grid: &MiniGrid) -> bool {
+        let next_board = |grid: &MiniGrid| {
+            grid.iter()
+                .enumerate()
+                .find(|&(_, &board)| !board.is_empty())
+                .map(|(index, &board)| (index, board))
+        };
+
+        if let Some((index, board)) = next_board(grid) {
+            let mut frontier = MiniGrid::default();
+            // Select only one bit that has not yet been visited
+            frontier[index] = board.lsb();
+            let connected = Self::flood_fill(&mut frontier, grid);
+
+            for i in 0..GRID_SIZE {
+                if (grid[i] & !connected[i]).0 > 0 {
+                    return false;
+                }
+            }
+        }
+
+        return true
     }
 
     pub fn num_connected_components(grid: &MiniGrid) -> usize {
@@ -831,8 +864,7 @@ impl MiniBitGrid {
         }
 
         grid[location.board_index] &= !location.mask;
-        let connected_components = Self::num_connected_components(&grid);
-        connected_components > 1
+        !Self::fast_single_connected_component(&grid)
     }
 
     fn neighborhood_to_grid(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,3 +9,4 @@ pub mod location;
 pub mod piece;
 pub mod testing_utils;
 pub mod uhp;
+pub mod magic_search;

--- a/src/magic_search.rs
+++ b/src/magic_search.rs
@@ -1,0 +1,43 @@
+use crate::bitgrid::gates::surround_power_set;
+use rand::{Rng, RngExt};
+use rand::{rngs::ChaCha8Rng, SeedableRng};
+
+// 1189240572695543808 - magic for converting powerset of surround to index into 64 bit array
+
+fn generate_magic_candidate(rng: &mut impl rand::Rng) -> u64 {
+    let mut candidate = rng.random::<u64>();
+    for i in 0..4 {
+        let and_mask = rng.random::<u64>();
+        candidate &= and_mask;
+    }
+
+    candidate
+}
+
+pub fn find_magic() -> u64 {
+    let powerset = surround_power_set()
+                        .into_iter()
+                        .map(|set| set.0)
+                        .collect::<Vec<u64>>();
+    let vec = vec![0u64; powerset.len()];
+    let upper_bits_func = |x: u64| x >> (64 - 6);
+    let mut rng = ChaCha8Rng::seed_from_u64(rand::random::<u64>());
+
+    for _ in 0..10000000 {
+        let candidate = generate_magic_candidate(&mut rng);
+        let mut seen = vec.clone();
+        let mut collision = false;
+        for (_, &test) in powerset.iter().enumerate() {
+            let index = upper_bits_func(candidate.wrapping_mul(test));
+            if seen[index as usize] != 0 {
+                collision = true;
+                break;
+            }
+            seen[index as usize] = test;
+        }
+        if !collision {
+            return candidate;
+        }
+    }
+    panic!("Could not find magic number");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod location;
 mod piece;
 mod testing_utils;
 mod uhp;
+mod magic_search;
 
 use clap::{Parser, Subcommand};
 use uhp::UHPInterface;
@@ -27,6 +28,10 @@ enum MainCommands {
 
     /// Runs a script to analyze the certain statistics for hive positions
     Analyze,
+
+    /// Runs a script to try and determine a magic number set up by 
+    /// the magic_search module
+    MagicSearch,
 
     /// Interprets a number as an Axial and prints the bitboard
     Bitboard { number: u64 },
@@ -54,6 +59,10 @@ pub fn main() {
         Some(MainCommands::Bitboard { number }) => {
             let bitboard = bitgrid::board::AxialBitboard::from_u64(number);
             println!("{}", bitboard);
+        }
+        Some(MainCommands::MagicSearch) => {
+            let magic_number = magic_search::find_magic();
+            println!("Found magic number: {}", magic_number);
         }
 
         None => run_universal_hive_protocol(),


### PR DESCRIPTION
- Speeds up the flood fill algo by skipping calculations on empty boards
- uses magic number indexing for perfect hashes
- skips roughly half of the num_connected_component cost on average (we only need to know whether there are 0, or 1 or >1 connected components)

Overall seeing nice 1.1x to 1.33x speedups across the board!